### PR TITLE
add-explanation-for-using-bluetooth

### DIFF
--- a/BlutoothManager/Info.plist
+++ b/BlutoothManager/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>for connecting to joey</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
add-explanation-for-using-bluetooth
explanation must be specified in info.plist